### PR TITLE
Port to Python3

### DIFF
--- a/rabaDB/Raba.py
+++ b/rabaDB/Raba.py
@@ -1,5 +1,5 @@
 import sqlite3 as sq
-import os, copy, types, pickle, random, json, abc, sys#, weakref
+import os, copy, pickle, random, json, abc, sys#, weakref
 from collections import MutableSequence
 
 from rabaDB.rabaSetup import RabaConnection, RabaConfiguration
@@ -31,7 +31,7 @@ def isRabaObjectPupa(v) :
 	return _recClassCheck(v.__class__, RabaPupa)
 
 def isPythonPrimitive(v) :
-	primTypes = [types.IntType, types.LongType, types.FloatType, types.StringType, types.UnicodeType, types.BufferType, types.NoneType]
+	primTypes = [int, float, str, type(None)]  # NOTE/TODO removed unicode, buffer?
 	for t in primTypes :
 		if isinstance(v, t) :
 			return True
@@ -179,7 +179,7 @@ class _RabaSingleton_MetaClass(type) :
 			uniqueStr = ''
 			if '_raba_uniques' in dct :
 				for c in dct['_raba_uniques'] :
-					if type(c) is types.StringType :
+					if type(c) is str :
 						uniqueStr += 'UNIQUE (%s) ON CONFLICT REPLACE, ' % c
 					elif len(c) == 1 :
 						uniqueStr += 'UNIQUE (%s) ON CONFLICT REPLACE, ' % c[0]
@@ -480,7 +480,7 @@ class Raba(object):
 		ff = []
 		rlf = []
 		tmpf = []
-		if type(fields) is types.StringType :
+		if type(fields) is str :
 			tmpf.append(fields)
 		else :
 			tmpf = fields

--- a/rabaDB/Raba.py
+++ b/rabaDB/Raba.py
@@ -1,9 +1,9 @@
 import sqlite3 as sq
-import os, copy, types, cPickle, random, json, abc, sys#, weakref
+import os, copy, types, pickle, random, json, abc, sys#, weakref
 from collections import MutableSequence
 
-from rabaSetup import RabaConnection, RabaConfiguration
-import fields as RabaFields
+from rabaDB.rabaSetup import RabaConnection, RabaConfiguration
+import rabaDB.fields as RabaFields
 
 def _recClassCheck(v, cls) :
 	if v is cls : return True
@@ -418,7 +418,7 @@ class Raba(object):
 			elmt = getattr(self._rabaClass, k)
 			if RabaFields.isPrimitiveField(elmt) :
 				try :
-					self.__setattr__(k, cPickle.loads(str(dbLine[i])))
+					self.__setattr__(k, pickle.loads(str(dbLine[i])))
 				except :
 					self.__setattr__(k, dbLine[i])
 
@@ -620,7 +620,7 @@ class Raba(object):
 				elif isPythonPrimitive(vv):
 					vSQL = vv
 				else :
-					vSQL = buffer(cPickle.dumps(vv))
+					vSQL = buffer(pickle.dumps(vv))
 
 				self.sqlSave[k] = vSQL
 
@@ -885,7 +885,7 @@ class RabaList(MutableSequence) :
 					elif isPythonPrimitive(e) :
 						values.append((self.anchorObj.raba_id, e, RabaFields.RABA_FIELD_TYPE_IS_PRIMITIVE, None, None, None))
 					else :
-						values.append((self.anchorObj.raba_id, buffer(cPickle.dumps(e)), RabaFields.RABA_FIELD_TYPE_IS_PRIMITIVE, None, None, None))
+						values.append((self.anchorObj.raba_id, buffer(pickle.dumps(e)), RabaFields.RABA_FIELD_TYPE_IS_PRIMITIVE, None, None, None))
 
 				self.connection.executeMany('INSERT INTO %s (anchor_raba_id, value, type, obj_raba_class_name, obj_raba_id, obj_raba_namespace) VALUES (?, ?, ?, ?, ?, ?)' % self.tableName, values)
 

--- a/rabaDB/Raba.py
+++ b/rabaDB/Raba.py
@@ -153,7 +153,7 @@ class _RabaSingleton_MetaClass(type) :
 					for base in bases :
 						i += getFields_rec(base.__name__, sqlFields, columns, columnsToLowerCase, base.__dict__, base.__bases__)
 
-				for k, v in dct.iteritems() :
+				for k, v in dct.items() :
 					if RabaFields.isField(v) :
 						sk = str(k)
 						if k.lower() != 'raba_id' and k.lower() != 'json' :
@@ -333,15 +333,13 @@ def removeFromRegistery(obj) :
 	elif isRabaList(obj) :
 		_unregisterRabaListInstance(obj)	
 
-class RabaPupa(object) :
+class RabaPupa(metaclass=_RabaPupaSingleton_Metaclass) :
 	"""One of the founding principles of RabaDB is to separate the storage from the code. Fields are stored in the DB while the processing only depends
 	on your python code. This approach ensures a higher degree of stability by preventing old objects from lurking inside the DB before popping out of nowhere several decades afterwards.
 	According to this apparoach, raba objects are not serialised but transformed into pupas before being stored. A pupa is a very light object that contains only a reference
 	to the raba object class, and it's unique raba_id. Upon asking for one of the attributes of a pupa, it magically transforms into a full fledged raba object. This process is completly transparent to the user. Pupas also have the advantage of being light weight and also ensure that the only raba objects loaded are those explicitely accessed, thus potentialy saving a lot of memory.
 	For a pupa self._rabaClass refers to the class of the object "inside" the pupa.
 	"""
-
-	__metaclass__ = _RabaPupaSingleton_Metaclass
 
 	def __init__(self, classObj, raba_id) :
 		self._rabaClass = classObj
@@ -391,9 +389,8 @@ class RabaPupa(object) :
 	def __repr__(self) :
 		return "<RabaObj pupa: %s, raba_id %s>" % (self._rabaClass.__name__, self.raba_id)
 
-class Raba(object):
+class Raba(metaclass=_RabaSingleton_MetaClass):
 	"All raba object inherit from this class"
-	__metaclass__ = _RabaSingleton_MetaClass
 	raba_id = RabaFields.Primitive()
 	json = RabaFields.Primitive()
 	_raba_abstract = True
@@ -413,7 +410,7 @@ class Raba(object):
 		self.json = dbLine[self.__class__.columns['json']]
 
 		lists = []
-		for kk, i in self.columns.iteritems() :
+		for kk, i in self.columns.items() :
 			k = self.columnsToLowerCase[kk.lower()]
 			elmt = getattr(self._rabaClass, k)
 			if RabaFields.isPrimitiveField(elmt) :
@@ -555,7 +552,7 @@ class Raba(object):
 			if not self.raba_id :
 				raise ValueError("Field raba_id of self has the not int value %s therefore i cannot save the object, sorry" % (self, self.raba_id))
 			
-			for k, v in self.listsToSave.iteritems() :
+			for k, v in self.listsToSave.items() :
 				v._save()
 				self.sqlSave[k] = len(v)
 				if not self._saved : #this dict is only for optimisation purpose for generating the insert sql
@@ -681,10 +678,9 @@ class Raba(object):
 		"returns a string of lisinting available fields"
 		return 'Available fields for %s: %s' %(cls.__name__, ', '.join(cls.getFields()))
 
-class RabaListPupa(MutableSequence) :
+class RabaListPupa(MutableSequence, metaclass=_RabaListPupaSingleton_Metaclass) :
 
 	_isRabaList = True
-	__metaclass__ = _RabaListPupaSingleton_Metaclass
 
 	def __init__(self, **kwargs) :
 		self._runtimeId = (self.__class__.__name__, random.random()) #this is using only during runtime ex, to avoid circular calls
@@ -710,7 +706,7 @@ class RabaListPupa(MutableSequence) :
 		#initFromPupa['raba_id'] = MutableSequence.__getattribute__(self, 'raba_id')
 
 		purge = MutableSequence.__getattribute__(self, '__dict__').keys()
-		for k in purge :
+		for k in list(purge) :
 			delattr(self, k)
 
 		RabaList.__init__(self, initFromPupa = initFromPupa)
@@ -759,12 +755,11 @@ class RabaListPupa(MutableSequence) :
 			self.develop()
 		return self.length
 
-class RabaList(MutableSequence) :
+class RabaList(MutableSequence, metaclass=_RabaListSingleton_Metaclass) :
 	"""A RabaList is a list that can only contain Raba objects of the same class or (Pupas of the same class). They represent one to many relations and are stored in separate
 	tables that contain only one single line"""
 
 	_isRabaList = True
-	__metaclass__ = _RabaListSingleton_Metaclass
 
 	def _checkElmt(self, v) :
 		if self.anchorObj != None :

--- a/rabaDB/examples/BasicExample.py
+++ b/rabaDB/examples/BasicExample.py
@@ -2,7 +2,7 @@ from rabaDB.rabaSetup import *
 RabaConfiguration('test', './dbTest_BasicExample.db')
 import rabaDB.Raba as R
 from rabaDB.filters import *
-from rabaDB.fields import *
+import rabaDB.fields as rf
 
 class Human(R.Raba) :
 	_raba_namespace = 'test'

--- a/rabaDB/fields.py
+++ b/rabaDB/fields.py
@@ -1,5 +1,5 @@
 import types
-import Raba
+import rabaDB.Raba
 
 RABA_FIELD_TYPE_IS_UNDEFINED = -1
 RABA_FIELD_TYPE_IS_PRIMITIVE = 0

--- a/rabaDB/fields.py
+++ b/rabaDB/fields.py
@@ -1,4 +1,4 @@
-import rabaDB.Raba as Raba
+#import rabaDB.Raba as Raba
 
 RABA_FIELD_TYPE_IS_UNDEFINED = -1
 RABA_FIELD_TYPE_IS_PRIMITIVE = 0
@@ -38,8 +38,8 @@ class Relation(RList) :
 		self.className = className
 		RList.__init__(self, ElmtConstrainFct, **ElmtConstrainFctWArgs)
 
-	def check(self, val) :
-		return Raba.isRabaObject(val) and ((self.className != None and val._rabaClass.__name__ == self.className) or self.className == None) and RList.check(self, val)
+#	def check(self, val) :
+#		return Raba.isRabaObject(val) and ((self.className != None and val._rabaClass.__name__ == self.className) or self.className == None) and RList.check(self, val)
 
 class Primitive(RabaField) :
 	_raba_type = RABA_FIELD_TYPE_IS_PRIMITIVE
@@ -73,15 +73,15 @@ class RabaObject(RabaField) :
 			self.className = className
 			self.classNamespace = classNamespace
 
-	def check(self, val) :
-		if val == self.default and self.default == None :
-			return True
-		retVal =  Raba.isRabaObject(val) and ((self.className != None and val._rabaClass.__name__ == self.className) or self.className == None) and RabaField.check(self, val)
-
-		if self.classNamespace == None :
-			return retVal
-		else :
-			return retVal and val._raba_namespace == self.classNamespace
+#	def check(self, val) :
+#		if val == self.default and self.default == None :
+#			return True
+#		retVal =  Raba.isRabaObject(val) and ((self.className != None and val._rabaClass.__name__ == self.className) or self.className == None) and RabaField.check(self, val)
+#
+#		if self.classNamespace == None :
+#			return retVal
+#		else :
+#			return retVal and val._raba_namespace == self.classNamespace
 
 	def __repr__(self) :
 		return '<field %s, class: %s , default: %s>' % (self.__class__.__name__, self.className, self.default)

--- a/rabaDB/fields.py
+++ b/rabaDB/fields.py
@@ -1,4 +1,3 @@
-import types
 import rabaDB.Raba
 
 RABA_FIELD_TYPE_IS_UNDEFINED = -1
@@ -65,7 +64,8 @@ class RabaObject(RabaField) :
 			raise ValueError("Default value is not a valid Raba Object")
 
 		RabaField.__init__(self,  default, constrainFct, **constrainFctWArgs)
-		if type(className) is not types.StringType :
+		if type(className) is not str :
+
 			assert isRabaClass(className)
 			self.className = RabaConnection(className._raba_namespace).getClass(className.__name__)
 			self.classNamespace = className._raba_namespace
@@ -98,4 +98,3 @@ def isRabaObjectField(v) :
 
 def isRabaListField(v) :
 	return hasattr(v.__class__, '_raba_type') and v.__class__._raba_type == RABA_FIELD_TYPE_IS_RABA_LIST
-

--- a/rabaDB/fields.py
+++ b/rabaDB/fields.py
@@ -1,4 +1,4 @@
-import rabaDB.Raba
+import rabaDB.Raba as Raba
 
 RABA_FIELD_TYPE_IS_UNDEFINED = -1
 RABA_FIELD_TYPE_IS_PRIMITIVE = 0

--- a/rabaDB/filters.py
+++ b/rabaDB/filters.py
@@ -1,4 +1,4 @@
-import re, types
+import re
 
 import rabaSetup as stp
 from Raba import *
@@ -52,7 +52,7 @@ class RabaQuery :
 		"""rabaClass can either be a raba class of a string of a raba class name. In the latter case you must provide the namespace argument.
 		If it's a Raba Class the argument is ignored. If you fear cicular imports use strings"""
 
-		if type(rabaClass) is types.StringType :
+		if type(rabaClass) is str :
 			self._raba_namespace = namespace
 			self.con = stp.RabaConnection(self._raba_namespace)
 			self.rabaClass = self.con.getClass(rabaClass)
@@ -78,7 +78,7 @@ class RabaQuery :
 
 		dstF = {}
 		if len(lstFilters) > 0 :
-			if type(lstFilters[0]) is types.DictType :
+			if type(lstFilters[0]) is dict :
 				dstF = lstFilters[0]
 				lstFilters = lstFilters[1:]
 
@@ -160,7 +160,7 @@ class RabaQuery :
 		for f in self.filters :
 			filt = []
 			for k, vv in f.iteritems() :
-				if type(vv) is types.ListType or type(vv) is types.TupleType :
+				if type(vv) in { list, tuple } :
 					sqlValues.extend(vv)
 					kk = 'OR %s ? '%k * len(vv)
 					kk = "(%s)" % kk[3:]

--- a/rabaDB/filters.py
+++ b/rabaDB/filters.py
@@ -1,8 +1,8 @@
 import re
 
-import rabaSetup as stp
-from Raba import *
-import fields as RabaFields
+import rabaDB.rabaSetup as stp
+from rabaDB.Raba import *
+import rabaDB.fields as RabaFields
 
 #####
 # TODO
@@ -156,7 +156,7 @@ class RabaQuery :
 		"Returns the query without performing it. If count, the query returned will be a SELECT COUNT() instead of a SELECT"
 		sqlFilters = []
 		sqlValues = []
-		# print self.filters
+		# print(self.filters)
 		for f in self.filters :
 			filt = []
 			for k, vv in f.iteritems() :
@@ -288,4 +288,4 @@ if __name__ == '__main__' :
 	rq.addFilter({'b->c' : c})
 	#rq.addFilter(['b->c.name = C'])
 	for a in rq.run() :
-		print a
+		print(a)

--- a/rabaDB/rabaSetup.py
+++ b/rabaDB/rabaSetup.py
@@ -34,7 +34,7 @@ class RabaConfiguration(object) :
 		if dbFile == None :
 			raise ValueError("""No configuration detected for namespace '%s'.
 			Have you forgotten to add: %s('%s', 'the path to you db file') just after the import of setup?""" % (namespace, self.__class__.__name__, namespace))
-		#print dbFile
+		#print(dbFile)
 		self.dbFile = dbFile
 
 class RabaConnection(object) :
@@ -204,14 +204,14 @@ class RabaConnection(object) :
 
 	def _debugActions(self, sql, values) :
 		if self._debugSQL :
-			print "Next query: %s\nWith params: %s\n(c)ontinue/(s)top:" % (sql, values)
+			print("Next query: %s\nWith params: %s\n(c)ontinue/(s)top:" % (sql, values))
 			while True :
 				val = raw_input().lower()
 				if val == 's' :
 					raise Exception("DEBUG STOPED!")
 				elif val == 'c' :
 					break
-		elif self._printQueries : print sql, values
+		elif self._printQueries : print(sql, values)
 
 		if self._enableStats :
 			self._logQuery(sql, values)
@@ -236,25 +236,25 @@ class RabaConnection(object) :
 	def printStats(self) :
 		if self._enableStats :
 			t = time.time() - self.startTime
-			print "====Raba Connection %s stats====" % (self.namespace)
+			print("====Raba Connection %s stats====" % (self.namespace))
 			if t < 60 :
-				print "Been running for: %fsc" % t
+				print("Been running for: %fsc" % t)
 			elif t < 3600 :
-				print "Been running for: %fmin" % (t/60)
+				print("Been running for: %fmin" % (t/60))
 			else :
-				print "Been running for: %fh" % (t/3600)
+				print("Been running for: %fh" % (t/3600))
 
-			print 'Query counts: '
+			print('Query counts: ')
 			for k, v in self.queryCounts.iteritems() :
-				print '\t', k
-				print "\t\t raw counts:", v
+				print('\t', k)
+				print("\t\t raw counts:", v)
 				if self.queryCounts['TOTAL'] > 0 :
-					print "\t\t ratio (total queries):", v/float(self.queryCounts['TOTAL'])
+					print("\t\t ratio (total queries):", v/float(self.queryCounts['TOTAL']))
 				else :
-					print "\t\t ratio (total queries): 0/0"
-				print "\t\t ratio (run time (sc)):", v/t
+					print("\t\t ratio (total queries): 0/0")
+				print("\t\t ratio (run time (sc)):", v/t)
 		else :
-			print "====Raba Connection %s stats====> you must enable stats first" % (self.namespace)
+			print("====Raba Connection %s stats====> you must enable stats first" % (self.namespace))
 
 	def beginTransaction(self) :
 		"Raba commits at each save, unless you begin a transaction in wich cas everything will be commited when endTransaction() is called"

--- a/rabaDB/rabaSetup.py
+++ b/rabaDB/rabaSetup.py
@@ -1,4 +1,4 @@
-import time, types, hashlib, sys
+import time, hashlib, sys
 import sqlite3 as sq
 
 #The limit number of variables in a query in sqlite (http://www.sqlite.org/limits.html). Same name as in sqlite if want to google it
@@ -104,7 +104,7 @@ class RabaConnection(object) :
 			typ = "INDEX"
 			w = ''
 
-		if type(fields) is types.ListType :
+		if type(fields) is list :
 			return "RABA_%s_%s_%s_on_%s" %(table, typ, w, '_X_'.join(fields))
 		else :
 			return "RABA_%s_%s_%s_on_%s" %(table, typ, w, fields)
@@ -126,7 +126,7 @@ class RabaConnection(object) :
 		else :
 			indexTable = self.makeIndexTableName(table, fields, where, whereValues)
 
-		if type(fields) is types.ListType :
+		if type(fields) is list :
 			sql = "CREATE INDEX IF NOT EXISTS %s on %s(%s)" %(indexTable, table, ', '.join(fields))
 		else :
 			sql = "CREATE INDEX IF NOT EXISTS %s on %s(%s)" %(indexTable, table, fields)

--- a/rabaDB/rabaSetup.py
+++ b/rabaDB/rabaSetup.py
@@ -8,7 +8,6 @@ class RabaNameSpaceSingleton(type):
 	_instances = {}
 
 	def __call__(cls, *args, **kwargs):
-		print(*args, kwargs)
 		if len(args) < 1 :
 			raise ValueError('The first argument to %s must be a namespace' % cls.__name__)
 
@@ -220,7 +219,7 @@ class RabaConnection(metaclass=RabaNameSpaceSingleton) :
 		sql = sql.strip()
 		self._debugActions(sql, values)
 		cur = self.connection.cursor()
-		cur.execute(sql, values)
+		cur.execute(sql, tuple(values))  # Note dict-values won't work.
 		return cur
 
 	def executemany(self, sql, values = [()]) :

--- a/rabaDB/rabaSetup.py
+++ b/rabaDB/rabaSetup.py
@@ -8,6 +8,7 @@ class RabaNameSpaceSingleton(type):
 	_instances = {}
 
 	def __call__(cls, *args, **kwargs):
+		print(*args, kwargs)
 		if len(args) < 1 :
 			raise ValueError('The first argument to %s must be a namespace' % cls.__name__)
 
@@ -21,27 +22,25 @@ class RabaNameSpaceSingleton(type):
 			cls._instances[key] = type.__call__(cls, *args, **kwargs)
 		return cls._instances[key]
 
-class RabaConfiguration(object) :
+class RabaConfiguration(metaclass=RabaNameSpaceSingleton) :
 	"""This class must be instanciated at the begining of the script just after the import of setup giving it the path to the the DB file. ex :
 
 	from rabaDB.setup import *
 	RabaConfiguration(namespace, './dbTest.db')
 
 	After the first instanciation you can call it without parameters. As this class is a Singleton, it will always return the same instance"""
-	__metaclass__ = RabaNameSpaceSingleton
 
 	def __init__(self, namespace, dbFile = None) :
 		if dbFile == None :
 			raise ValueError("""No configuration detected for namespace '%s'.
-			Have you forgotten to add: %s('%s', 'the path to you db file') just after the import of setup?""" % (namespace, self.__class__.__name__, namespace))
+			Have you forgotten to add: %s('%s', 'the path to you db file') just after the import of setup?\n(%s""" % (namespace, self.__class__.__name__, namespace,
+                                                                                                                                  (dbFile, self)))
 		#print(dbFile)
 		self.dbFile = dbFile
 
-class RabaConnection(object) :
+class RabaConnection(metaclass=RabaNameSpaceSingleton) :
 	"""A class that manages the connection to the sqlite3 database. Don't be afraid to call RabaConnection() as much as you want. By default Raba tries to be smart and commits only when
 	you save a rabaobject but if you want complete controle over the commit process you can use setAutoCommit(False) and then use commit() manually"""
-
-	__metaclass__ = RabaNameSpaceSingleton
 
 	def __init__(self, namespace) :
 


### PR DESCRIPTION
It wasn't too hard.. Only one of the examples works though, and only once.. Not sure if it did better before?

* Changed way metaclass was specified.
* Removed reference to `types` package. `buffer` and `unicode` no  longer in there.
* `iteritems` -> `items` and a `tuple` in there somewhere since Sqlite `execute` does not play well with `dict_items`
* Commented out some `check` functions in `field.py` because they were involved in circular importing of packages.
* `cPickle` replaced with simply `pickle`.